### PR TITLE
Adjust banner to support topmost position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.3.3] 2025-01-29
-- ## Added
+### Added
 - topmost position for banner
 - support for vertical scrolling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.3] 2025-01-29
+- ## Added
+- topmost position for banner
+- support for vertical scrolling
+
 ## [1.3.2] 2022-06-09
 - Fixed bug where top banner was positioned top and bottom
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shopgate Connect - configurable banner
 
-Adds Banner to the top of pages. A banner can be an image, text or text with background image. Linking is possible.
+Adds one or multiple banners to top or bottom of the pages. A banner can be an image, text or text with background image. Linking is possible.
 
 ## Features
 - Multiple banners per page
@@ -25,7 +25,7 @@ Examples: `/category/:categoryId`, `/item/:productId`, `/category`, `/`, `/cart`
 
 - `ids (Array)` (optional): Array of Ids for the provided pattern. If omitted it's a wildcard for every Id.
 
-- `position (string)` (optional): Position where the banner should be shown. Available positions `top` (default), `bottom`
+- `position (string)` (optional): Position where the banner should be shown. Available positions `top` (default), `bottom`, `topmost`
 
 - `link (string)` (optional): Link to the page that should be opened. Relative urls will be opened in the app. Absolute in inAppBrowser
 
@@ -36,18 +36,21 @@ Examples: `/category/:categoryId`, `/item/:productId`, `/category`, `/`, `/cart`
 - `productSliderIds (Array)` (optional): Array of productsIds for ProductSlider.
 Example:
 ```json
- "productSliderIds": [
+{
+  "productSliderIds": [
     "166",
     "640",
     "850"
-],
+  ]
+}
 ```
 
 - `slides (Array)` (optional): Array of slides. Each entry represents a slide with same settings for a banner as above. So link, content, wrapperStyles.
 
 Example:
 ```json
-"slides": [
+{
+  "slides": [
     {
       "content": {
         "cssBackground": "#000",
@@ -69,20 +72,28 @@ Example:
       },
       "link": "/foo"
     }
-]
+  ]
+}
 ```
 
 - `sliderSettings (Object)` (optional): Settings for slider
 
 Example:
 ```json
-"sliderSettings": {
+{
+  "sliderSettings": {
     "autoPlay": false,
     "controls": true,
     "indicators": true,
     "loop": false,
     "slidesPerView": 1,
-    "freeMode": false
+    "freeMode": false,
+    "direction": "vertical",
+    "autoHeight": true,
+    "style": {
+      "marginBottom": 10
+    }
+  }
 }
 ```
 
@@ -92,8 +103,10 @@ Example:
 
 Example:
 ```json
-"content": {
-   "imageOnlyUrl": "https://cdn.img.com/image1.jpg"
+{
+  "content": {
+    "imageOnlyUrl": "https://cdn.img.com/image1.jpg"
+  }
 }
 ```
 
@@ -106,11 +119,13 @@ Example:
 
 Example:
 ```json
-"content": {
-   "cssBackground": "#000",
-   "textColor": "#fff"
-   "h2": "Line <strong>1</strong>",
-   "h3": "Line 2",
+{
+  "content": {
+    "cssBackground": "#000",
+    "textColor": "#fff",
+    "h2": "Line <strong>1</strong>",
+    "h3": "Line 2"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Example:
 ```
 
 - `sliderSettings (Object)` (optional): Settings for slider
+- see https://v9.swiperjs.com/swiper-api#parameters for possible slider parameters
 
 Example:
 ```json
@@ -88,7 +89,6 @@ Example:
     "loop": false,
     "slidesPerView": 1,
     "freeMode": false,
-    "direction": "vertical",
     "autoHeight": true,
     "style": {
       "marginBottom": 10

--- a/extension-config.json
+++ b/extension-config.json
@@ -3,6 +3,12 @@
   "id": "@shopgate-project/configurable-banner",
   "components": [
     {
+      "id": "BannersTopmost",
+      "type": "portals",
+      "path": "frontend/portals/Banners/BannersTopmost.jsx",
+      "target": "app-bar.default.before"
+    },
+    {
       "id": "BannersTop",
       "type": "portals",
       "path": "frontend/portals/Banners",

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -1,2 +1,3 @@
+export const BANNER_POSITION_TOPMOST = 'topmost';
 export const BANNER_POSITION_TOP = 'top';
 export const BANNER_POSITION_BOTTOM = 'bottom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,8 +38,5 @@
     "react-transition-group": "^2.2.1",
     "react-hot-loader": "^3.1.3",
     "react-transform-catch-errors": "^1.0.2"
-  },
-  "peerDependencies": {
-    "@shopgate/engage": "^6.7.2"
   }
 }

--- a/frontend/portals/Banners/Banner/index.jsx
+++ b/frontend/portals/Banners/Banner/index.jsx
@@ -10,7 +10,7 @@ import connect from './connector';
  * @param {Object} wrapperStyles wrapperStyles
  * @param {Object} contentConfig contentConfig
  * @param {string} link link
- * @returns {JSX}
+ * @returns {JSX.Element}
  */
 const buildSlideContent = (wrapperStyles, contentConfig, link) => {
   let content = null;
@@ -20,10 +20,11 @@ const buildSlideContent = (wrapperStyles, contentConfig, link) => {
     h2,
     textColor,
     cssBackground,
+    altText,
   } = contentConfig;
 
   if (imageOnlyUrl) {
-    content = (<img src={imageOnlyUrl} className={css(wrapperStyles)} alt="" />);
+    content = (<img src={imageOnlyUrl} className={css(wrapperStyles)} alt={altText || ''} />);
   } else if (h3 || h2) {
     content = (
       <div className={`${styles.wrapper(cssBackground, textColor)} ${css(wrapperStyles)}`}>
@@ -50,7 +51,7 @@ const buildSlideContent = (wrapperStyles, contentConfig, link) => {
 
 /**
  * Banner component
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const Banner = ({
   content: contentConfig,

--- a/frontend/portals/Banners/BannersBottom.jsx
+++ b/frontend/portals/Banners/BannersBottom.jsx
@@ -4,7 +4,7 @@ import { BANNER_POSITION_BOTTOM } from '../../constants';
 
 /**
  * Banners component
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const BannersBottom = () => (
   <Banners position={BANNER_POSITION_BOTTOM} />

--- a/frontend/portals/Banners/BannersTopmost.jsx
+++ b/frontend/portals/Banners/BannersTopmost.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Banners from './index';
+import { BANNER_POSITION_TOPMOST } from '../../constants';
+
+/**
+ * Banners component
+ * @return {JSX.Element}
+ */
+const BannersTopmost = () => (
+  <Banners position={BANNER_POSITION_TOPMOST} />
+);
+
+export default BannersTopmost;

--- a/frontend/portals/Banners/index.jsx
+++ b/frontend/portals/Banners/index.jsx
@@ -5,7 +5,7 @@ import Banner from './Banner';
 
 /**
  * Banners component
- * @return {JSX}
+ * @return {JSX.Element}
  */
 const Banners = ({ banners }) => {
   if (!banners.length) {


### PR DESCRIPTION
## Description

The banner is adjusted to support the topmost position on the page.

Attention: Needs the swiper package in version 9.4.1 or above as well as the PWA version 7.23.0.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update
