### PR TITLE
PS-283 Fix banner display for non-hex page route params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.1] 2025-06-18
+### Fixed
+- Fixed banner matching for CMS page routes using slug-based parameters
+
 ## [1.5.0] 2025-02-28
 ### Added
 - Improved accessibility: made link in banner accessible to screen readers

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ _Please make sure your images are compressed and optimized to reduce the loadtim
 Set it to `null` to cause requests configEndpoint url
 
 - `routePattern (string)`: Pattern of the route where the banner should be shown. Use `*` to add it to all routes.
-Examples: `/category/:categoryId`, `/item/:productId`, `/category`, `/`, `/cart`
+Examples: `/category/:categoryId`, `/item/:productId`, `/category`, `/`, `/cart`, `/page/:pageId`
 
-- `ids (Array)` (optional): Array of Ids for the provided pattern. If omitted it's a wildcard for every Id.
+- `ids (Array)` (optional): Array of Ids for the provided pattern. If omitted it's a wildcard for every Id. For CMS routes using slug-based URLs (e.g. `/page/shipping-information`), this array should contain the expected page key instead of Ids, e.g. `["shipping-information"]`.
 
 - `position (string)` (optional): Position where the banner should be shown. Available positions `top` (default), `bottom`, `topmost`
 

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.5.1-beta.1",
   "id": "@shopgate-project/configurable-banner",
   "components": [
     {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/configurable-banner",
-  "version": "1.3.2",
+  "version": "1.5.1",
   "description": "configurable banner",
   "license": "Apache-2.0",
   "scripts": {

--- a/frontend/portals/Banners/selectors.js
+++ b/frontend/portals/Banners/selectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { getCurrentRoute } from '@shopgate/pwa-common/selectors/router';
 import { hex2bin } from '@shopgate/pwa-common/helpers/data';
+import { PAGE_PATTERN } from '@shopgate/pwa-common/constants/RoutePaths';
 import { getConfig } from '../../config/selectors';
 import { BANNER_POSITION_TOP } from '../../constants';
 
@@ -23,7 +24,13 @@ export const getBannersForCurrentPage = createSelector(
       }
 
       if (Array.isArray(ids) && ids.length) {
-        return Object.values(route.params).some(param => ids.includes(hex2bin(param)));
+        // do not apply hex2bin for page routes, as their params are not hex-encoded
+        const isPageRoute = route.pattern === PAGE_PATTERN;
+
+        return Object.values(route.params).some((param) => {
+          const value = isPageRoute ? param : hex2bin(param);
+          return ids.includes(value);
+        });
       }
 
       return true;


### PR DESCRIPTION
## Description

Banners are now displayed correctly for page routes with plain text parameters.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update