### PR TITLE
Updated auto hide functionality for topmost banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.6.1 2025-06-20
+### Changed
+- Banners on `topmost` position with `hideOnScroll` active are not shown till user scrolled back to top again
+
 ## [1.6.0] 2025-06-18
 ### Added
 - Add "hideOnScroll" option to config, which hides the topmost banner when the user scrolls down (needs PWA >= 7.27.2)

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "id": "@shopgate-project/configurable-banner",
   "components": [
     {

--- a/frontend/portals/Banners/index.jsx
+++ b/frontend/portals/Banners/index.jsx
@@ -47,6 +47,7 @@ const Banners = ({ banners }) => {
             <ScrollHeader
               ref={bannerRef}
               hideOnScroll
+              onlyShowAtTop
               className={classNames(scrollHeaderStyle)}
               classes={{
                 scrolledIn,


### PR DESCRIPTION
## Description

Banners on `topmost` position with `hideOnScroll` active are not shown till user scrolled back to top again

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update
